### PR TITLE
Revert "Bugfix/60052 remove redundant default tax delete object term relationships athorne"

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6369,8 +6369,8 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	 */
 	do_action( 'delete_attachment', $post_id, $post );
 
-	// Delete relationships for category and post tag if they exist.
-	wp_delete_object_term_relationships( $post_id );
+	wp_delete_object_term_relationships( $post_id, array( 'category', 'post_tag' ) );
+	wp_delete_object_term_relationships( $post_id, get_object_taxonomies( $post->post_type ) );
 
 	// Delete all for any posts.
 	delete_metadata( 'post', null, '_thumbnail_id', $post_id, true );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1963,15 +1963,10 @@ function wp_count_terms( $args = array(), $deprecated = '' ) {
  * @since 2.3.0
  *
  * @param int          $object_id  The term object ID that refers to the term.
- * @param string|array|void  $taxonomies List of taxonomy names or single taxonomy name.
+ * @param string|array $taxonomies List of taxonomy names or single taxonomy name.
  */
-function wp_delete_object_term_relationships( $object_id, $taxonomies = '' ) {
+function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
 	$object_id = (int) $object_id;
-
-	// If Taxonomies is empty use new function called get all taxonomies that have a term. 
-	if ( empty( $taxonomies ) ) {
-		$taxonomies = get_object_taxonomies( get_post_type( $object_id ) ); // This is placeholder
-	}
 
 	if ( ! is_array( $taxonomies ) ) {
 		$taxonomies = array( $taxonomies );
@@ -1979,9 +1974,6 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies = '' ) {
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
-		if ( is_wp_error( $term_ids ) ) {
-			continue;
-		}
 		$term_ids = array_map( 'intval', $term_ids );
 		wp_remove_object_terms( $object_id, $term_ids, $taxonomy );
 	}

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6096,54 +6096,6 @@ EOF;
 			'height' => 100,
 		);
 	}
-
-
-	/**
-	 * Test deleting an attachment when 'post_tag' has been unregistered,
-	 * simulating the scenario.
-	 * 
-	 * @ticket 60052
-	 */
-	public function test_delete_attachment_with_unregistered_post_tag() {
-		global $wp_taxonomies;
-
-		// Create a test attachment.
-		$attachment_id = self::factory()->attachment->create_upload_object(
-			DIR_TESTDATA . '/images/canola.jpg'
-		);
-
-		// Create and assign 'category' and 'post_tag' terms to the attachment.
-		$category_id = wp_create_category( 'Test Category 60052' );
-		$tag_id      = wp_insert_term( 'Test Tag 60052', 'post_tag' )['term_id'];
-
-		wp_set_object_terms( $attachment_id, array( $category_id ), 'category' );
-		wp_set_object_terms( $attachment_id, array( $tag_id ), 'post_tag' );
-
-		// Verify the attachment actually has these terms.
-		$this->assertNotEmpty( wp_get_object_terms( $attachment_id, 'category' ) );
-		$this->assertNotEmpty( wp_get_object_terms( $attachment_id, 'post_tag' ) );
-
-		// Unregister 'post_tag' by removing it from $wp_taxonomies.
-		// We’ll store a backup so we can restore it later.
-		$saved_post_tag = $wp_taxonomies['post_tag'];
-		unset( $wp_taxonomies['post_tag'] );
-
-		// Now, delete the attachment. In #60052, this would fail if 'post_tag' is missing,
-		// but the patched core should handle it gracefully.
-		$deleted_post = wp_delete_attachment( $attachment_id, true );
-
-		// Restore the 'post_tag' taxonomy so it doesn’t break other tests.
-		$wp_taxonomies['post_tag'] = $saved_post_tag;
-
-		// Verify the attachment was deleted (returns WP_Post object on success).
-		$this->assertInstanceOf( 'WP_Post', $deleted_post );
-
-		// Ensure there are no remaining terms for category/post_tag on that (now deleted) ID.
-		// Typically this means the relationships are removed; 
-		// the post itself is gone, but let's just be thorough.
-		$this->assertEmpty( wp_get_object_terms( $attachment_id, 'category' ) );
-		$this->assertEmpty( wp_get_object_terms( $attachment_id, 'post_tag' ) );
-	}
 }
 
 /**


### PR DESCRIPTION
Reverts JPrentice-thecode/wordpress-develop#1