### PR TITLE
Bugfix/60052 remove redundant default tax delete object term relationships athorne

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6370,7 +6370,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	do_action( 'delete_attachment', $post_id, $post );
 
 	// Delete relationships for category and post tag if they exist.
-	wp_delete_object_term_relationships( $post_id );
+	wp_delete_object_term_relationships( $post_id, array_merge( get_object_taxonomies( $post->post_type ), array( 'category', 'post_tag' ) ) );
 
 	// Delete all for any posts.
 	delete_metadata( 'post', null, '_thumbnail_id', $post_id, true );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1968,20 +1968,24 @@ function wp_count_terms( $args = array(), $deprecated = '' ) {
 function wp_delete_object_term_relationships( $object_id, $taxonomies = '' ) {
 	$object_id = (int) $object_id;
 
-	// If Taxonomies is empty use new function called get all taxonomies that have a term. 
-	if ( empty( $taxonomies ) ) {
-		$taxonomies = get_object_taxonomies( get_post_type( $object_id ) ); // This is placeholder, change for james function.
-	}
-
 	if ( ! is_array( $taxonomies ) ) {
 		$taxonomies = array( $taxonomies );
 	}
+	
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
-		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
-		if ( is_wp_error( $term_ids ) ) {
+		// Check if the taxonomy exists first, necessary for attachment where category and post_tag have to be manually added.
+		if ( ! taxonomy_exists( $taxonomy ) ) {
 			continue;
 		}
+			
+		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
+
+		// Check if wp_get_object_terms() returned a WP_Error or an empty array.
+		if ( is_wp_error( $term_ids ) || empty( $term_ids ) ) {
+			continue;
+		}
+
 		$term_ids = array_map( 'intval', $term_ids );
 		wp_remove_object_terms( $object_id, $term_ids, $taxonomy );
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1970,7 +1970,7 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies = '' ) {
 
 	// If Taxonomies is empty use new function called get all taxonomies that have a term. 
 	if ( empty( $taxonomies ) ) {
-		$taxonomies = get_object_taxonomies( get_post_type( $object_id ) ); // This is placeholder
+		$taxonomies = get_object_taxonomies( get_post_type( $object_id ) ); // This is placeholder, change for james function.
 	}
 
 	if ( ! is_array( $taxonomies ) ) {


### PR DESCRIPTION
This PR addresses #60052 Unit Test, where unregistering a default taxonomy (such as post_tag) causes a fatal error when deleting media attachments. The changes ensure that wp_delete_object_term_relationships() and wp_delete_attachment() gracefully handle missing default taxonomies. A new unit test is added to confirm the fix by simulating a scenario where post_tag is unregistered before deleting an attachment, preventing the previously reported error.

Trac ticket:
#60052 on WordPress Trac